### PR TITLE
Publish to GitHub packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '14'
           registry-url: 'https://npm.pkg.github.com'
 
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - github-package
 
 jobs:
   publish:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish npm package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish package
+        run: npm publish --registry=https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - github-package
 
 jobs:
   publish:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesignal/meteor-protomongo",
-  "version": "3.1.1",
+  "version": "3.1.1-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesignal/meteor-protomongo",
-  "version": "3.1.1-beta.1",
+  "version": "3.1.1",
   "description": "Extends meteor/mongo with handy async methods",
   "main": "lib/mongo.js",
   "types": "lib/mongo.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesignal/meteor-protomongo",
-  "version": "3.1.1",
+  "version": "3.1.1-beta.0",
   "description": "Extends meteor/mongo with handy async methods",
   "main": "lib/mongo.js",
   "types": "lib/mongo.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codesignal/meteor-protomongo",
-  "version": "3.1.1-beta.0",
+  "version": "3.1.1-beta.1",
   "description": "Extends meteor/mongo with handy async methods",
   "main": "lib/mongo.js",
   "types": "lib/mongo.d.ts",


### PR DESCRIPTION
## Changes

Added a workflow to publish to GitHub packages.

## Testing
* Passing workflow https://github.com/CodeSignal/meteor-protomongo/actions/runs/9871384889/job/27259193328?pr=622
* Deployed package https://github.com/CodeSignal/meteor-protomongo/pkgs/npm/meteor-protomongo/241671739
  
### Manual
* Inside an empty folder, create a package with `npm init -y`
* Run `npm i @codesignal/meteor-protomongo --registry=https://npm.pkg.github.com`
* Check the package content in node modules

## Before Deployment
* Currently the package is deployed under the beta tag. Will update the workflow file before merging.
* We have this branch in the workflow file. Will remove it before merging as well.
